### PR TITLE
separate the address of the LDAP server from the domain it authenticates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Create a `profiles.clj` file in the project directory with the configuration set
   :ldap
   {:host
      {:address         "my-ldap-server.ca"
+      :domain          "domain.ca"
       :port            389
       :connect-timeout (* 1000 5)
       :timeout         (* 1000 30)}}}}}

--- a/src/clj/memory_hole/routes/services/auth.clj
+++ b/src/clj/memory_hole/routes/services/auth.clj
@@ -16,7 +16,7 @@
 
 (defn authenticate-ldap [userid pass]
   (let [conn           (client/get-connection ldap-pool)
-        qualified-name (str userid "@" (-> host :host :address))]
+        qualified-name (str userid "@" (-> host :host :domain))]
     (try
       (when (client/bind? conn qualified-name pass)
         (-> (client/search conn


### PR DESCRIPTION
Fixes #25 .