### PR TITLE
Fix migration script by adding semicolon after the `update`.

### DIFF
--- a/resources/migrations/20171110130215-add-group-id-to-support-issues.up.sql
+++ b/resources/migrations/20171110130215-add-group-id-to-support-issues.up.sql
@@ -1,4 +1,4 @@
 alter table support_issues
-add column group_id text REFERENCES groups(group_id) DEFERRABLE;
-update support_issues set group_id = (select group_id from groups where group_name = 'Default')
+  add column group_id text REFERENCES groups(group_id) DEFERRABLE;
+update support_issues set group_id = (select group_id from groups where group_name = 'Default');
 alter table support_issues ALTER COLUMN group_id SET NOT NULL;


### PR DESCRIPTION
There was missing semicolon which lead to the following error with `lein run migrate`:
```
2018-01-23 10:53:50,178 [main] INFO  migratus.core - Up 20171110130215-add-group-id-to-support-issues
2018-01-23 10:53:50,194 [main] ERROR migratus.migration.sql - failed to execute command:
 alter table support_issues
add column group_id text REFERENCES groups(group_id) DEFERRABLE;
update support_issues set group_id = (select group_id from groups where group_name = 'Default')
alter table support_issues ALTER COLUMN group_id SET NOT NULL;
Failure: ERROR: syntax error at or near "alter"
  Position: 98
2018-01-23 10:53:50,195 [main] ERROR migratus.database - Migration add-group-id-to-support-issues failed because ERROR: syntax error at or near "alter"
  Position: 98 backing out
2018-01-23 10:53:50,201 [main] INFO  migratus.core - Ending migrations
Exception in thread "main" org.postgresql.util.PSQLException: ERROR: syntax error at or near "alter"
```